### PR TITLE
docker hubにimageをpushしてECSで使えるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,9 @@ ui-nginx/rebuild:
 ui/rebuild:
 	$(DOCKER_COMPOSE) rm --force --stop ui
 	$(DOCKER_COMPOSE) up --build -d ui
+
+push: build/image
+	$(DOCKER) push shuzon21/headphonista:latest
+
+build/image:
+	$(DOCKER_COMPOSE) build --pull --no-cache ui_nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: "3"
 services:
   ui_nginx:
-    image: nginx:mainline-alpine
+    image: shuzon21/headphonista
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.nginx
     volumes:
       - ./ui/build:/usr/share/nginx/html:ro
     ports:

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,0 +1,1 @@
+FROM nginx:mainline-alpine


### PR DESCRIPTION
ECSはECRかdocker hubにイメージがホストされていないと使えない。
nginxのimageをビルドしてECSから利用できるようにする