### PR TITLE
tmp dirにビルド成果物をコピーしてdocker build時にimage内に取り込むようにした

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,8 @@ push: build/image
 	$(DOCKER) push shuzon21/headphonista:latest
 
 build/image:
+	rm -rf ./docker/tmp
+	mkdir ./docker/tmp
+	cp -r ./ui/build ./docker/tmp
 	$(DOCKER_COMPOSE) build --pull --no-cache ui_nginx
+	rm -rf ./docker/tmp

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,1 +1,2 @@
 FROM nginx:mainline-alpine
+COPY ./tmp/build /usr/share/nginx/html


### PR DESCRIPTION
#8 

docker imageにjs成果物が含まれておらずnginx indexがデフォルトのままになっていたのを修正