### PR TITLE
商品ページの追加/商品概要の機能を追加

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { Switch, Route, BrowserRouter as Router } from "react-router-dom";
 import React from "react";
 import { Header } from "./View/Header";
 import { Top } from "./View/Top/index";
+import { Item } from "./View/Item/index";
 import { Container } from "@material-ui/core";
 
 const App = (): JSX.Element => {
@@ -15,6 +16,9 @@ const App = (): JSX.Element => {
           <Switch>
             <Route exact path="/">
               <Top />
+            </Route>
+            <Route exact path="/top">
+              <Item />
             </Route>
           </Switch>
         </Router>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,7 +17,7 @@ const App = (): JSX.Element => {
             <Route exact path="/">
               <Top />
             </Route>
-            <Route exact path="/top">
+            <Route exact path="/item">
               <Item />
             </Route>
           </Switch>

--- a/ui/src/View/Item/ItemBreadcrumbs.tsx
+++ b/ui/src/View/Item/ItemBreadcrumbs.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+import Breadcrumbs from "@material-ui/core/Breadcrumbs";
+import Typography from "@material-ui/core/Typography";
+import Link from "@material-ui/core/Link";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    breadcrumbs: {
+      margin: theme.spacing(2, 1),
+      "& > * + *": {
+        marginTop: theme.spacing(2),
+      },
+    },
+  })
+);
+
+export default function ItemBreadcrumbs(props: { itemName: string }) {
+  const c = useStyles();
+
+  return (
+    <div className={c.breadcrumbs}>
+      <Breadcrumbs separator="›" aria-label="breadcrumb">
+        <Link color="inherit" href="/">
+          <Typography variant="body2">商品一覧</Typography>
+        </Link>
+        <Typography color="textPrimary" variant="body2">
+          {props.itemName}
+        </Typography>
+      </Breadcrumbs>
+    </div>
+  );
+}

--- a/ui/src/View/Item/Overview.tsx
+++ b/ui/src/View/Item/Overview.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-export const Summary = (props: {
+export const Overview = (props: {
   reviewStars: number;
   price: number;
   amazonUrl: string;

--- a/ui/src/View/Item/Summary.tsx
+++ b/ui/src/View/Item/Summary.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { Button } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+import StarIcon from "@material-ui/icons/Star";
+import StarHalfIcon from "@material-ui/icons/StarHalf";
+import ShoppingCartOutlinedIcon from "@material-ui/icons/ShoppingCartOutlined";
+import DirectionsIcon from "@material-ui/icons/Directions";
+import { displayPrice } from "../../utils/price";
+import Typography from "@material-ui/core/Typography";
+
+import red from "@material-ui/core/colors/red";
+import amber from "@material-ui/core/colors/amber";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    star: {
+      color: amber[400],
+    },
+    price: {
+      color: red[500],
+    },
+    buyNowBtn: {
+      margin: theme.spacing(1, 0),
+      width: "100%",
+      color: "#fff",
+      background: amber[600],
+    },
+    buyNowBtnContent: {
+      padding: theme.spacing(0, 1, 0, 0),
+      display: "inline",
+      verticalAlign: "middle",
+    },
+    productPageBtn: {
+      margin: theme.spacing(1, 0),
+      width: "100%",
+      color: "#fff",
+      background: red["A200"],
+    },
+    productPageBtnContent: {
+      padding: theme.spacing(0, 1, 0, 0),
+      display: "inline",
+      verticalAlign: "middle",
+    },
+  })
+);
+
+export const Summary = (props: {
+  reviewStars: number;
+  price: number;
+  amazonUrl: string;
+  productPageUrl: string;
+  itemName: string;
+}): JSX.Element => {
+  const c = useStyles();
+
+  const StarElements = () => {
+    const fullStarCount = Math.floor(props.reviewStars);
+    const hasHalfStar = props.reviewStars % 1 > 0;
+
+    const stars = [...new Array(fullStarCount)].map((_, i) => {
+      return <StarIcon key={`star${i}`} className={c.star} />;
+    });
+
+    if (hasHalfStar) {
+      stars.push(<StarHalfIcon key={"halfstar"} className={c.star} />);
+    }
+
+    return <>{stars}</>;
+  };
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <StarElements />
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="body2">
+          プロユースの本格音質をご自宅でも手軽に。
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="h6" className={c.price}>
+          {displayPrice(props.price)}
+        </Typography>
+      </Grid>
+      <Grid item xs={6}>
+        <BuyNowButton url={props.amazonUrl} />
+      </Grid>
+      <Grid item xs={6}>
+        <ProductPageButton url={props.productPageUrl} />
+      </Grid>
+    </>
+  );
+};
+
+const BuyNowButton = (props: { url: string }): JSX.Element => {
+  const c = useStyles();
+  return (
+    <Button className={c.buyNowBtn} href={props.url}>
+      <ShoppingCartOutlinedIcon className={c.buyNowBtnContent} />
+      <Typography variant="caption" className={c.buyNowBtnContent}>
+        BUY NOW
+      </Typography>
+    </Button>
+  );
+};
+
+const ProductPageButton = (props: { url: string }): JSX.Element => {
+  const c = useStyles();
+  return (
+    <Button className={c.productPageBtn} href={props.url}>
+      <DirectionsIcon className={c.productPageBtnContent} />
+      <Typography variant="caption" className={c.productPageBtnContent}>
+        公式ページ
+      </Typography>
+    </Button>
+  );
+};

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -1,10 +1,44 @@
 import React from "react";
-import { makeStyles } from "@material-ui/core";
 
-const useStyle = makeStyles((theme) => ({}));
+import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+import Breadcrumbs from "@material-ui/core/Breadcrumbs";
+import Typography from "@material-ui/core/Typography";
+import Link from "@material-ui/core/Link";
+import NavigateNextIcon from "@material-ui/icons/NavigateNext";
+import { typography } from "material-ui/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    breadcrumbs: {
+      margin: theme.spacing(2, 1),
+      "& > * + *": {
+        marginTop: theme.spacing(2),
+      },
+    },
+  })
+);
 
 export const Item = (): JSX.Element => {
-  const c = useStyle();
-
-  return <></>;
+  return (
+    <>
+      <ItemBreadcrumbs />
+    </>
+  );
 };
+
+export default function ItemBreadcrumbs() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.breadcrumbs}>
+      <Breadcrumbs separator="›" aria-label="breadcrumb">
+        <Link color="inherit" href="/">
+          <Typography variant="body2">商品一覧</Typography>
+        </Link>
+        <Typography color="textPrimary" variant="body2">
+          SONY MDR-M1ST
+        </Typography>
+      </Breadcrumbs>
+    </div>
+  );
+}

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -29,12 +29,16 @@ const useStyles = makeStyles((theme: Theme) =>
     star: {
       color: amber[400],
     },
+    price: {
+      color: red[500],
+    },
   })
 );
 
 export const Item = (): JSX.Element => {
   const c = useStyles();
   const reviewStars = 4.5;
+  const price = 30000;
 
   const StarElements = () => {
     const fullStarCount = Math.floor(reviewStars);
@@ -49,6 +53,14 @@ export const Item = (): JSX.Element => {
     }
 
     return <>{stars}</>;
+  };
+
+  const displayPrice = (price: number) => {
+    const formatter = new Intl.NumberFormat("ja-JP", {
+      style: "currency",
+      currency: "JPY",
+    });
+    return formatter.format(price);
   };
 
   return (
@@ -68,6 +80,11 @@ export const Item = (): JSX.Element => {
           <Grid item xs={12}>
             <Typography variant="body2">
               プロユースの本格音質をご自宅でも手軽に。
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant="h6" className={c.price}>
+              {displayPrice(price)}
             </Typography>
           </Grid>
         </Grid>

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -6,6 +6,8 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import { Divider } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
+import StarIcon from "@material-ui/icons/Star";
+import StarHalfIcon from "@material-ui/icons/StarHalf";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -21,6 +23,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     divider: {
       background: theme.palette.warning.main,
+    },
+    star: {
+      color: "#FFCA00",
     },
   })
 );
@@ -38,6 +43,13 @@ export const Item = (): JSX.Element => {
               SONY MDR-M1ST
             </Typography>
             <Divider classes={{ root: c.divider }} />
+          </Grid>
+          <Grid item xs={12}>
+            <StarIcon className={c.star} />
+            <StarIcon className={c.star} />
+            <StarIcon className={c.star} />
+            <StarIcon className={c.star} />
+            <StarHalfIcon className={c.star} />
           </Grid>
         </Grid>
       </div>

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -4,8 +4,7 @@ import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
-import NavigateNextIcon from "@material-ui/icons/NavigateNext";
-import { typography } from "material-ui/styles";
+import { Divider } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -16,8 +15,12 @@ const useStyles = makeStyles((theme: Theme) =>
         marginTop: theme.spacing(2),
       },
     },
-    itemName: {
+    item: {
       margin: theme.spacing(0, 2),
+      textAlign: "left",
+    },
+    divider: {
+      background: theme.palette.warning.main,
     },
   })
 );
@@ -28,13 +31,16 @@ export const Item = (): JSX.Element => {
   return (
     <>
       <ItemBreadcrumbs />
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <Typography variant="h6" align="left" className={c.itemName}>
-            SONY MDR-M1ST
-          </Typography>
+      <div className={c.item}>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <Typography variant="h6" align="left">
+              SONY MDR-M1ST
+            </Typography>
+            <Divider classes={{ root: c.divider }} />
+          </Grid>
         </Grid>
-      </Grid>
+      </div>
     </>
   );
 };

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -8,6 +8,8 @@ import { Divider } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
 import StarIcon from "@material-ui/icons/Star";
 import StarHalfIcon from "@material-ui/icons/StarHalf";
+import red from "@material-ui/core/colors/red";
+import amber from "@material-ui/core/colors/amber";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -25,13 +27,29 @@ const useStyles = makeStyles((theme: Theme) =>
       background: theme.palette.warning.main,
     },
     star: {
-      color: "#FFCA00",
+      color: amber[400],
     },
   })
 );
 
 export const Item = (): JSX.Element => {
   const c = useStyles();
+  const reviewStars = 4.5;
+
+  const StarElements = () => {
+    const fullStarCount = Math.floor(reviewStars);
+    const hasHalfStar = reviewStars % 1 > 0;
+
+    const stars = [...new Array(fullStarCount)].map((_) => {
+      return <StarIcon className={c.star} />;
+    });
+
+    if (hasHalfStar) {
+      stars.push(<StarHalfIcon className={c.star} />);
+    }
+
+    return <>{stars}</>;
+  };
 
   return (
     <>
@@ -45,11 +63,7 @@ export const Item = (): JSX.Element => {
             <Divider classes={{ root: c.divider }} />
           </Grid>
           <Grid item xs={12}>
-            <StarIcon className={c.star} />
-            <StarIcon className={c.star} />
-            <StarIcon className={c.star} />
-            <StarIcon className={c.star} />
-            <StarHalfIcon className={c.star} />
+            <StarElements />
           </Grid>
           <Grid item xs={12}>
             <Typography variant="body2">

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -12,6 +12,7 @@ import red from "@material-ui/core/colors/red";
 import amber from "@material-ui/core/colors/amber";
 import ShoppingCartOutlinedIcon from "@material-ui/icons/ShoppingCartOutlined";
 import DirectionsIcon from "@material-ui/icons/Directions";
+import { displayPrice } from "../../utils/price";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -67,60 +68,17 @@ export const Item = (): JSX.Element => {
   const productPageUrl = "https://www.sony.jp/headphone/products/MDR-M1ST/";
   const itemName = "SONY MDR-M1ST";
 
-  const StarElements = () => {
-    const fullStarCount = Math.floor(reviewStars);
-    const hasHalfStar = reviewStars % 1 > 0;
-
-    const stars = [...new Array(fullStarCount)].map((_, i) => {
-      return <StarIcon key={`star${i}`} className={c.star} />;
-    });
-
-    if (hasHalfStar) {
-      stars.push(<StarHalfIcon key={"halfstar"} className={c.star} />);
-    }
-
-    return <>{stars}</>;
-  };
-
-  const displayPrice = (price: number) => {
-    const formatter = new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-    });
-    return formatter.format(price);
-  };
-
   return (
     <>
       <ItemBreadcrumbs itemName={itemName} />
       <div className={c.item}>
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            <Typography variant="h6" align="left">
-              {itemName}
-            </Typography>
-            <Divider classes={{ root: c.divider }} />
-          </Grid>
-          <Grid item xs={12}>
-            <StarElements />
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="body2">
-              プロユースの本格音質をご自宅でも手軽に。
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="h6" className={c.price}>
-              {displayPrice(price)}
-            </Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <BuyNowButton url={amazonUrl} />
-          </Grid>
-          <Grid item xs={6}>
-            <ProductPageButton url={productPageUrl} />
-          </Grid>
-        </Grid>
+        <Summary
+          reviewStars={reviewStars}
+          price={price}
+          amazonUrl={amazonUrl}
+          productPageUrl={productPageUrl}
+          itemName={itemName}
+        />
       </div>
     </>
   );
@@ -142,6 +100,61 @@ export default function ItemBreadcrumbs(props: { itemName: string }) {
     </div>
   );
 }
+
+const Summary = (props: {
+  reviewStars: number;
+  price: number;
+  amazonUrl: string;
+  productPageUrl: string;
+  itemName: string;
+}): JSX.Element => {
+  const c = useStyles();
+
+  const StarElements = () => {
+    const fullStarCount = Math.floor(props.reviewStars);
+    const hasHalfStar = props.reviewStars % 1 > 0;
+
+    const stars = [...new Array(fullStarCount)].map((_, i) => {
+      return <StarIcon key={`star${i}`} className={c.star} />;
+    });
+
+    if (hasHalfStar) {
+      stars.push(<StarHalfIcon key={"halfstar"} className={c.star} />);
+    }
+
+    return <>{stars}</>;
+  };
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Typography variant="h6" align="left">
+          {props.itemName}
+        </Typography>
+        <Divider classes={{ root: c.divider }} />
+      </Grid>
+      <Grid item xs={12}>
+        <StarElements />
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="body2">
+          プロユースの本格音質をご自宅でも手軽に。
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="h6" className={c.price}>
+          {displayPrice(props.price)}
+        </Typography>
+      </Grid>
+      <Grid item xs={6}>
+        <BuyNowButton url={props.amazonUrl} />
+      </Grid>
+      <Grid item xs={6}>
+        <ProductPageButton url={props.productPageUrl} />
+      </Grid>
+    </Grid>
+  );
+};
 
 const BuyNowButton = (props: { url: string }): JSX.Element => {
   const c = useStyles();

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { Summary } from "./Summary";
+import { Overview } from "./Overview";
 import ItemBreadcrumbs from "./ItemBreadcrumbs";
 import Typography from "@material-ui/core/Typography";
 import { Divider, Grid } from "@material-ui/core";
@@ -37,7 +37,7 @@ export const Item = (): JSX.Element => {
             </Typography>
             <Divider classes={{ root: c.divider }} />
           </Grid>
-          <Summary
+          <Overview
             reviewStars={reviewStars}
             price={price}
             amazonUrl={amazonUrl}

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -6,6 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
 import { typography } from "material-ui/styles";
+import { Grid } from "@material-ui/core";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -15,22 +16,34 @@ const useStyles = makeStyles((theme: Theme) =>
         marginTop: theme.spacing(2),
       },
     },
+    itemName: {
+      margin: theme.spacing(0, 2),
+    },
   })
 );
 
 export const Item = (): JSX.Element => {
+  const c = useStyles();
+
   return (
     <>
       <ItemBreadcrumbs />
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <Typography variant="h6" align="left" className={c.itemName}>
+            SONY MDR-M1ST
+          </Typography>
+        </Grid>
+      </Grid>
     </>
   );
 };
 
 export default function ItemBreadcrumbs() {
-  const classes = useStyles();
+  const c = useStyles();
 
   return (
-    <div className={classes.breadcrumbs}>
+    <div className={c.breadcrumbs}>
       <Breadcrumbs separator="›" aria-label="breadcrumb">
         <Link color="inherit" href="/">
           <Typography variant="body2">商品一覧</Typography>

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -65,6 +65,7 @@ export const Item = (): JSX.Element => {
   const price = 30000;
   const amazonUrl = "https://amzn.to/2YHPkLo";
   const productPageUrl = "https://www.sony.jp/headphone/products/MDR-M1ST/";
+  const itemName = "SONY MDR-M1ST";
 
   const StarElements = () => {
     const fullStarCount = Math.floor(reviewStars);
@@ -91,12 +92,12 @@ export const Item = (): JSX.Element => {
 
   return (
     <>
-      <ItemBreadcrumbs />
+      <ItemBreadcrumbs itemName={itemName} />
       <div className={c.item}>
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <Typography variant="h6" align="left">
-              SONY MDR-M1ST
+              {itemName}
             </Typography>
             <Divider classes={{ root: c.divider }} />
           </Grid>
@@ -125,7 +126,7 @@ export const Item = (): JSX.Element => {
   );
 };
 
-export default function ItemBreadcrumbs() {
+export default function ItemBreadcrumbs(props: { itemName: string }) {
   const c = useStyles();
 
   return (
@@ -135,7 +136,7 @@ export default function ItemBreadcrumbs() {
           <Typography variant="body2">商品一覧</Typography>
         </Link>
         <Typography color="textPrimary" variant="body2">
-          SONY MDR-M1ST
+          {props.itemName}
         </Typography>
       </Breadcrumbs>
     </div>

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core";
+
+const useStyle = makeStyles((theme) => ({}));
+
+export const Item = (): JSX.Element => {
+  const c = useStyle();
+
+  return <></>;
+};

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -1,61 +1,19 @@
 import React from "react";
 
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import Breadcrumbs from "@material-ui/core/Breadcrumbs";
+import { Summary } from "./Summary";
+import ItemBreadcrumbs from "./ItemBreadcrumbs";
 import Typography from "@material-ui/core/Typography";
-import Link from "@material-ui/core/Link";
-import { Button, Divider } from "@material-ui/core";
-import { Grid } from "@material-ui/core";
-import StarIcon from "@material-ui/icons/Star";
-import StarHalfIcon from "@material-ui/icons/StarHalf";
-import red from "@material-ui/core/colors/red";
-import amber from "@material-ui/core/colors/amber";
-import ShoppingCartOutlinedIcon from "@material-ui/icons/ShoppingCartOutlined";
-import DirectionsIcon from "@material-ui/icons/Directions";
-import { displayPrice } from "../../utils/price";
+import { Divider, Grid } from "@material-ui/core";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    breadcrumbs: {
-      margin: theme.spacing(2, 1),
-      "& > * + *": {
-        marginTop: theme.spacing(2),
-      },
-    },
     item: {
       margin: theme.spacing(0, 2),
       textAlign: "left",
     },
     divider: {
       background: theme.palette.warning.main,
-    },
-    star: {
-      color: amber[400],
-    },
-    price: {
-      color: red[500],
-    },
-    buyNowBtn: {
-      margin: theme.spacing(1, 0),
-      width: "100%",
-      color: "#fff",
-      background: amber[600],
-    },
-    buyNowBtnContent: {
-      padding: theme.spacing(0, 1, 0, 0),
-      display: "inline",
-      verticalAlign: "middle",
-    },
-    productPageBtn: {
-      margin: theme.spacing(1, 0),
-      width: "100%",
-      color: "#fff",
-      background: red["A200"],
-    },
-    productPageBtnContent: {
-      padding: theme.spacing(0, 1, 0, 0),
-      display: "inline",
-      verticalAlign: "middle",
     },
   })
 );
@@ -72,110 +30,22 @@ export const Item = (): JSX.Element => {
     <>
       <ItemBreadcrumbs itemName={itemName} />
       <div className={c.item}>
-        <Summary
-          reviewStars={reviewStars}
-          price={price}
-          amazonUrl={amazonUrl}
-          productPageUrl={productPageUrl}
-          itemName={itemName}
-        />
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <Typography variant="h6" align="left">
+              {itemName}
+            </Typography>
+            <Divider classes={{ root: c.divider }} />
+          </Grid>
+          <Summary
+            reviewStars={reviewStars}
+            price={price}
+            amazonUrl={amazonUrl}
+            productPageUrl={productPageUrl}
+            itemName={itemName}
+          />
+        </Grid>
       </div>
     </>
-  );
-};
-
-export default function ItemBreadcrumbs(props: { itemName: string }) {
-  const c = useStyles();
-
-  return (
-    <div className={c.breadcrumbs}>
-      <Breadcrumbs separator="›" aria-label="breadcrumb">
-        <Link color="inherit" href="/">
-          <Typography variant="body2">商品一覧</Typography>
-        </Link>
-        <Typography color="textPrimary" variant="body2">
-          {props.itemName}
-        </Typography>
-      </Breadcrumbs>
-    </div>
-  );
-}
-
-const Summary = (props: {
-  reviewStars: number;
-  price: number;
-  amazonUrl: string;
-  productPageUrl: string;
-  itemName: string;
-}): JSX.Element => {
-  const c = useStyles();
-
-  const StarElements = () => {
-    const fullStarCount = Math.floor(props.reviewStars);
-    const hasHalfStar = props.reviewStars % 1 > 0;
-
-    const stars = [...new Array(fullStarCount)].map((_, i) => {
-      return <StarIcon key={`star${i}`} className={c.star} />;
-    });
-
-    if (hasHalfStar) {
-      stars.push(<StarHalfIcon key={"halfstar"} className={c.star} />);
-    }
-
-    return <>{stars}</>;
-  };
-
-  return (
-    <Grid container spacing={3}>
-      <Grid item xs={12}>
-        <Typography variant="h6" align="left">
-          {props.itemName}
-        </Typography>
-        <Divider classes={{ root: c.divider }} />
-      </Grid>
-      <Grid item xs={12}>
-        <StarElements />
-      </Grid>
-      <Grid item xs={12}>
-        <Typography variant="body2">
-          プロユースの本格音質をご自宅でも手軽に。
-        </Typography>
-      </Grid>
-      <Grid item xs={12}>
-        <Typography variant="h6" className={c.price}>
-          {displayPrice(props.price)}
-        </Typography>
-      </Grid>
-      <Grid item xs={6}>
-        <BuyNowButton url={props.amazonUrl} />
-      </Grid>
-      <Grid item xs={6}>
-        <ProductPageButton url={props.productPageUrl} />
-      </Grid>
-    </Grid>
-  );
-};
-
-const BuyNowButton = (props: { url: string }): JSX.Element => {
-  const c = useStyles();
-  return (
-    <Button className={c.buyNowBtn} href={props.url}>
-      <ShoppingCartOutlinedIcon className={c.buyNowBtnContent} />
-      <Typography variant="caption" className={c.buyNowBtnContent}>
-        BUY NOW
-      </Typography>
-    </Button>
-  );
-};
-
-const ProductPageButton = (props: { url: string }): JSX.Element => {
-  const c = useStyles();
-  return (
-    <Button className={c.productPageBtn} href={props.url}>
-      <DirectionsIcon className={c.productPageBtnContent} />
-      <Typography variant="caption" className={c.productPageBtnContent}>
-        公式ページ
-      </Typography>
-    </Button>
   );
 };

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -4,12 +4,13 @@ import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
-import { Divider } from "@material-ui/core";
+import { Button, Divider } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
 import StarIcon from "@material-ui/icons/Star";
 import StarHalfIcon from "@material-ui/icons/StarHalf";
 import red from "@material-ui/core/colors/red";
 import amber from "@material-ui/core/colors/amber";
+import ShoppingCartOutlinedIcon from "@material-ui/icons/ShoppingCartOutlined";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -32,6 +33,17 @@ const useStyles = makeStyles((theme: Theme) =>
     price: {
       color: red[500],
     },
+    buyNowBtn: {
+      margin: theme.spacing(1, 0),
+      width: "100%",
+      color: "#fff",
+      background: "#FFB21E",
+    },
+    buyNowBtnContent: {
+      padding: theme.spacing(0, 1, 0, 0),
+      display: "inline",
+      verticalAlign: "middle",
+    },
   })
 );
 
@@ -39,6 +51,7 @@ export const Item = (): JSX.Element => {
   const c = useStyles();
   const reviewStars = 4.5;
   const price = 30000;
+  const amazonUrl = "https://amazon.co.jp";
 
   const StarElements = () => {
     const fullStarCount = Math.floor(reviewStars);
@@ -87,6 +100,10 @@ export const Item = (): JSX.Element => {
               {displayPrice(price)}
             </Typography>
           </Grid>
+          <Grid item xs={6}>
+            <BuyNowButton url={amazonUrl} />
+          </Grid>
+          <Grid item xs={6}></Grid>
         </Grid>
       </div>
     </>
@@ -109,3 +126,15 @@ export default function ItemBreadcrumbs() {
     </div>
   );
 }
+
+const BuyNowButton = (props: { url: string }): JSX.Element => {
+  const c = useStyles();
+  return (
+    <Button className={c.buyNowBtn} href={props.url}>
+      <ShoppingCartOutlinedIcon className={c.buyNowBtnContent} />
+      <Typography variant="caption" className={c.buyNowBtnContent}>
+        BUY NOW
+      </Typography>
+    </Button>
+  );
+};

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -40,12 +40,12 @@ export const Item = (): JSX.Element => {
     const fullStarCount = Math.floor(reviewStars);
     const hasHalfStar = reviewStars % 1 > 0;
 
-    const stars = [...new Array(fullStarCount)].map((_) => {
-      return <StarIcon className={c.star} />;
+    const stars = [...new Array(fullStarCount)].map((_, i) => {
+      return <StarIcon key={`star${i}`} className={c.star} />;
     });
 
     if (hasHalfStar) {
-      stars.push(<StarHalfIcon className={c.star} />);
+      stars.push(<StarHalfIcon key={"halfstar"} className={c.star} />);
     }
 
     return <>{stars}</>;

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -11,6 +11,7 @@ import StarHalfIcon from "@material-ui/icons/StarHalf";
 import red from "@material-ui/core/colors/red";
 import amber from "@material-ui/core/colors/amber";
 import ShoppingCartOutlinedIcon from "@material-ui/icons/ShoppingCartOutlined";
+import DirectionsIcon from "@material-ui/icons/Directions";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -37,9 +38,20 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: theme.spacing(1, 0),
       width: "100%",
       color: "#fff",
-      background: "#FFB21E",
+      background: amber[600],
     },
     buyNowBtnContent: {
+      padding: theme.spacing(0, 1, 0, 0),
+      display: "inline",
+      verticalAlign: "middle",
+    },
+    productPageBtn: {
+      margin: theme.spacing(1, 0),
+      width: "100%",
+      color: "#fff",
+      background: red["A200"],
+    },
+    productPageBtnContent: {
       padding: theme.spacing(0, 1, 0, 0),
       display: "inline",
       verticalAlign: "middle",
@@ -51,7 +63,8 @@ export const Item = (): JSX.Element => {
   const c = useStyles();
   const reviewStars = 4.5;
   const price = 30000;
-  const amazonUrl = "https://amazon.co.jp";
+  const amazonUrl = "https://amzn.to/2YHPkLo";
+  const productPageUrl = "https://www.sony.jp/headphone/products/MDR-M1ST/";
 
   const StarElements = () => {
     const fullStarCount = Math.floor(reviewStars);
@@ -103,7 +116,9 @@ export const Item = (): JSX.Element => {
           <Grid item xs={6}>
             <BuyNowButton url={amazonUrl} />
           </Grid>
-          <Grid item xs={6}></Grid>
+          <Grid item xs={6}>
+            <ProductPageButton url={productPageUrl} />
+          </Grid>
         </Grid>
       </div>
     </>
@@ -134,6 +149,18 @@ const BuyNowButton = (props: { url: string }): JSX.Element => {
       <ShoppingCartOutlinedIcon className={c.buyNowBtnContent} />
       <Typography variant="caption" className={c.buyNowBtnContent}>
         BUY NOW
+      </Typography>
+    </Button>
+  );
+};
+
+const ProductPageButton = (props: { url: string }): JSX.Element => {
+  const c = useStyles();
+  return (
+    <Button className={c.productPageBtn} href={props.url}>
+      <DirectionsIcon className={c.productPageBtnContent} />
+      <Typography variant="caption" className={c.productPageBtnContent}>
+        公式ページ
       </Typography>
     </Button>
   );

--- a/ui/src/View/Item/index.tsx
+++ b/ui/src/View/Item/index.tsx
@@ -51,6 +51,11 @@ export const Item = (): JSX.Element => {
             <StarIcon className={c.star} />
             <StarHalfIcon className={c.star} />
           </Grid>
+          <Grid item xs={12}>
+            <Typography variant="body2">
+              プロユースの本格音質をご自宅でも手軽に。
+            </Typography>
+          </Grid>
         </Grid>
       </div>
     </>

--- a/ui/src/utils/price.ts
+++ b/ui/src/utils/price.ts
@@ -1,0 +1,8 @@
+export const displayPrice = (price: number) => {
+  const options = {
+    style: "currency",
+    currency: "JPY",
+  };
+  const formatter = new Intl.NumberFormat("ja-JP", options);
+  return formatter.format(price);
+};


### PR DESCRIPTION
`/item` で商品ページが出るように。

**やったこと**
- m1stのページをベタガキで作る
- `/item` のルートで1itemの商品レビューを書く
- 名前、星、Amazonボタン、公式ボタンの追加

**やらなかったこと**

- itemごとのルーティング
- 画像
- 詳細記事
- グラフ

<img src=https://user-images.githubusercontent.com/5877377/106763603-57cc9280-667a-11eb-9418-410b4355385a.png 
 width=400px />
